### PR TITLE
Removed wrong saving of layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
     "lint:style": "stylelint **/*.{vue,scss} --fix",
     "lint:test": "eslint --ext .js,.ts,.tsx,.vue src/** dev-server/** docs/** scripts/** && stylelint **/*.{vue,scss}",
     "postpublish": "pinst --enable",
-    "precommit": "lint-staged -c ./.husky/.lintstagedrc -q",
-    "prepare": "is-ci || husky install",
     "prepublishOnly": "pinst --disable",
     "prettier": "prettier --write \"{src,dev-server,docs}/**/*.{ts,js,json,css,pcss,scss,vue,html,md}\"",
     "prettier:scripts": "prettier --write \"scripts/**/*.{ts,js,json}\"",

--- a/src/components/grid-layout.vue
+++ b/src/components/grid-layout.vue
@@ -345,6 +345,7 @@ function layoutUpdate() {
 
       state.lastLayoutLength = currentLayout.value.length
       initResponsiveFeatures()
+      if (props.responsive) responsiveGridLayout()
     }
 
     compact(currentLayout.value, props.verticalCompact)

--- a/src/components/grid-layout.vue
+++ b/src/components/grid-layout.vue
@@ -517,9 +517,9 @@ function responsiveGridLayout() {
   const newCols = getColsFromBreakpoint(newBreakpoint, props.cols)
 
   // save actual layout in layouts
-  if (!isNull(state.lastBreakpoint) && !state.layouts[state.lastBreakpoint]) {
-    state.layouts[state.lastBreakpoint] = cloneLayout(currentLayout.value)
-  }
+  // if (!isNull(state.lastBreakpoint) && !state.layouts[state.lastBreakpoint]) {
+  //   state.layouts[state.lastBreakpoint] = cloneLayout(currentLayout.value)
+  // }
 
   // Find or generate a new layout.
   const layout = findOrGenerateResponsiveLayout(


### PR DESCRIPTION
Removed a saving of layout in responsiveGridLayout(). The saving was happening before findOrGenerateResponsiveLayout and this caused the originalLayout to be saved as layout for the current breakpoint. This caused some plots to overlap if the number of column in the originalLayout was bigger than the number of columns allowed by the current breakpoint. Furthermore the layout is correctly saved after findOrGenerateResponsiveLayout so I think the efficency is unaltered