### PR TITLE
fix: navigator may not exist

### DIFF
--- a/src/components/grid-item.vue
+++ b/src/components/grid-item.vue
@@ -296,7 +296,10 @@ onBeforeUnmount(() => {
 
 defineExpose({ state, wrapper })
 
-const isAndroid = navigator.userAgent.toLowerCase().includes('android')
+const isAndroid =
+  typeof navigator !== 'undefined'
+    ? navigator.userAgent.toLowerCase().includes('android')
+    : false
 
 const resizableAndNotStatic = computed(() => state.resizable && !props.static)
 const renderRtl = computed(() => (layout.isMirrored ? !state.rtl : state.rtl))


### PR DESCRIPTION
I'm using Nuxt. When I turned on SSR, the following error was thrown:
```
navigator is undefined
```

Because `navigator` does not exist on server side. I see others also met this issue #29 when using Uniapp.

This PR checks whether `navigator` exists before accessing it.

fix #29