### PR TITLE
fix: resizing along the edge should affect only one axis

### DIFF
--- a/src/components/grid-item.vue
+++ b/src/components/grid-item.vue
@@ -484,6 +484,16 @@ function handleResize(event: MouseEvent) {
       break
     }
     case 'resizemove': {
+      // A vertical resize ignores the horizontal delta
+      if (!event.edges.right && !event.edges.left) {
+        lastW = x
+      }
+
+      // An horizontal resize ignores the vertical delta
+      if (!event.edges.top && !event.edges.bottom) {
+        lastH = y
+      }
+
       const coreEvent = createCoreData(lastW, lastH, x, y)
       if (renderRtl.value) {
         newSize.width = state.resizing.width - coreEvent.deltaX / state.transformScale


### PR DESCRIPTION
## Current behavior
Irrespective of where the resize action originates from, both width and height are updated

## Expected behavior
The one shown under "Resizing" at [interactjs.io](https://interactjs.io/)

When resizing an item from:
- top/bottom edge: the item can be resized only vertically
- left/right edge: the item can be resized only horizontally
- corner: the item can be resized both vertically and horizontally

