### PR TITLE
Fix RTL resizing issue when widget reaches minimum width

### DIFF
--- a/src/components/grid-item.vue
+++ b/src/components/grid-item.vue
@@ -820,8 +820,8 @@ function tryMakeResizable() {
 
     const opts: Record<string, any> = {
       edges: {
-        left: false,
-        right: `.${resizerClass.value[0]}`,
+        left: renderRtl.value ? `.${resizerClass.value[0]}` : false,
+        right: !renderRtl.value ? `.${resizerClass.value[0]}` : false,
         bottom: `.${resizerClass.value[0]}`,
         top: false
       },


### PR DESCRIPTION
### Issue
When using the `isMirrored `(RTL) mode, widgets could be resized freely until they reached their minimum width. However, once the widget was at its smallest size, it became locked and could no longer be expanded again. This caused usability issues, preventing users from resizing the widget back to a larger width.

### Resolution
This fix ensures that widgets in RTL mode can be resized both ways, even after reaching the minimum width. Now, users can shrink and expand the widget without getting stuck.

### Impact

- Resolves unexpected behavior in RTL mode.
- Ensures consistency between LTR and RTL resizing behavior.
- Allows for smoother user interactions when adjusting widget sizes.