### PR TITLE
fix: when window resize trigger resizeEventHandler, placeholder shouldn't hide (#46)

### DIFF
--- a/src/components/grid-layout.vue
+++ b/src/components/grid-layout.vue
@@ -431,7 +431,7 @@ function resizeEvent(
     })
     // this.$broadcast("updateWidth", this.width);
     emitter.emit('updateWidth', state.width)
-  } else {
+  } else if (eventName) {
     nextTick(() => {
       state.isDragging = false
     })


### PR DESCRIPTION
When window resize event trigger the handler, it will try to close the placeholder by set isDragging to false, which should only closed by resizeend event, then cause placeholder closed unexpected #46 